### PR TITLE
Fix first tab close bug

### DIFF
--- a/src/view/webview.js
+++ b/src/view/webview.js
@@ -177,7 +177,13 @@ module.exports = (emitter, state) => {
       w.close();
     }
 
-    changeView(id - 1);
+    id = id - 1;
+
+    if (id < 0) {
+      id = 0;
+    }
+
+    changeView(id);
   };
 
   /*


### PR DESCRIPTION
When closing the first tab the next tab's id is set to `-1` which does not exist in the tabs array.